### PR TITLE
Made things more flexible

### DIFF
--- a/CacheTagsBundle/Invalidator/Invalidator.php
+++ b/CacheTagsBundle/Invalidator/Invalidator.php
@@ -3,7 +3,7 @@
 namespace lbarulski\CacheTagsBundle\Invalidator;
 
 use lbarulski\CacheTagsBundle\Service\Repository;
-use lbarulski\CacheTagsBundle\Tag\TagInterface;
+use lbarulski\CacheTagsBundle\Tag\CacheTagInterface;
 
 class Invalidator implements InvalidatorInterface
 {
@@ -20,7 +20,10 @@ class Invalidator implements InvalidatorInterface
 		$this->repository = $repository;
 	}
 
-	public function invalidate(TagInterface $tag)
+	/**
+	 * @param CacheTagInterface $tag
+	 */
+	public function invalidate(CacheTagInterface $tag)
 	{
 		$this->repository->add($tag);
 	}

--- a/CacheTagsBundle/Invalidator/InvalidatorInterface.php
+++ b/CacheTagsBundle/Invalidator/InvalidatorInterface.php
@@ -2,9 +2,12 @@
 
 namespace lbarulski\CacheTagsBundle\Invalidator;
 
-use lbarulski\CacheTagsBundle\Tag\TagInterface;
+use lbarulski\CacheTagsBundle\Tag\CacheTagInterface;
 
 interface InvalidatorInterface
 {
-	public function invalidate(TagInterface $tag);
+	/**
+	 * @param CacheTagInterface $tag
+	 */
+	public function invalidate(CacheTagInterface $tag);
 }

--- a/CacheTagsBundle/Listener/InvalidatorListener.php
+++ b/CacheTagsBundle/Listener/InvalidatorListener.php
@@ -4,7 +4,7 @@ namespace lbarulski\CacheTagsBundle\Listener;
 
 use lbarulski\CacheTagsBundle\Invalidator\Proxy\ManagerInterface;
 use lbarulski\CacheTagsBundle\Service\Repository;
-use lbarulski\CacheTagsBundle\Tag\TagInterface;
+use lbarulski\CacheTagsBundle\Tag\CacheTagInterface;
 
 class InvalidatorListener
 {
@@ -35,11 +35,11 @@ class InvalidatorListener
 	}
 
 	/**
-	 * @param TagInterface $tag
+	 * @param CacheTagInterface $tag
 	 */
-	private function invalidateTag(TagInterface $tag)
+	private function invalidateTag(CacheTagInterface $tag)
 	{
-		$tagValue = $tag->getTag();
+		$tagValue = $tag->getCacheTag();
 		$proxies  = $this->manager->getProxies();
 		foreach ($proxies as $proxy)
 		{

--- a/CacheTagsBundle/Service/Repository.php
+++ b/CacheTagsBundle/Service/Repository.php
@@ -6,25 +6,25 @@
 
 namespace lbarulski\CacheTagsBundle\Service;
 
-use lbarulski\CacheTagsBundle\Tag\TagInterface;
+use lbarulski\CacheTagsBundle\Tag\CacheTagInterface;
 
 class Repository
 {
 	/**
-	 * @var TagInterface[]
+	 * @var CacheTagInterface[]
 	 */
 	private $tags = [];
 
 	/**
-	 * @param TagInterface $tag
+	 * @param CacheTagInterface $tag
 	 */
-	public function add(TagInterface $tag)
+	public function add(CacheTagInterface $tag)
 	{
 		$this->tags[] = $tag;
 	}
 
 	/**
-	 * @return TagInterface[]
+	 * @return CacheTagInterface[]
 	 */
 	public function getTags()
 	{

--- a/CacheTagsBundle/Service/Tagger.php
+++ b/CacheTagsBundle/Service/Tagger.php
@@ -6,7 +6,7 @@
 
 namespace lbarulski\CacheTagsBundle\Service;
 
-use lbarulski\CacheTagsBundle\Tag\TagInterface;
+use lbarulski\CacheTagsBundle\Tag\CacheTagInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 class Tagger
@@ -24,7 +24,7 @@ class Tagger
 
 	/**
 	 * @param Response       $response
-	 * @param TagInterface[] $tags
+	 * @param CacheTagInterface[] $tags
 	 * @param bool           $replace
 	 */
 	public function tagResponse(Response $response, $tags, $replace = false)
@@ -32,7 +32,7 @@ class Tagger
 		$tagValues = [];
 		foreach ($tags as $tag)
 		{
-			$tagValues[] = $tag->getTag();
+			$tagValues[] = $tag->getCacheTag();
 		}
 
 		if (!$replace && $response->headers->has($this->headerName))

--- a/CacheTagsBundle/Tag/CacheTagInterface.php
+++ b/CacheTagsBundle/Tag/CacheTagInterface.php
@@ -6,10 +6,10 @@
 
 namespace lbarulski\CacheTagsBundle\Tag;
 
-interface TagInterface
+interface CacheTagInterface
 {
 	/**
 	 * @return string
 	 */
-	public function getTag();
+	public function getCacheTag();
 }

--- a/CacheTagsBundle/Tag/Plain.php
+++ b/CacheTagsBundle/Tag/Plain.php
@@ -6,7 +6,7 @@
 
 namespace lbarulski\CacheTagsBundle\Tag;
 
-class Plain implements TagInterface
+class Plain implements CacheTagInterface
 {
 	/**
 	 * @var string
@@ -22,7 +22,7 @@ class Plain implements TagInterface
 	}
 
 	/** {@inheritdoc} */
-	public function getTag()
+	public function getCacheTag()
 	{
 		return $this->value;
 	}

--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ public function articleAction(Request $request)
 ```php
 // Acme\MainBundle\Entity\Article.php
 
-use lbarulski\CacheTagsBundle\Tag\TagInterface;
+use lbarulski\CacheTagsBundle\Tag\CacheTagInterface;
 
-class Article implements TagInterface
+class Article implements CacheTagInterface
 {
     ...
     
-    public function getTag()
+    public function getCacheTag()
 	{
 		return 'article_'.$this->getId();
 	}


### PR DESCRIPTION
Replaced interface and method name to make them more flexible in public projects. Method name "getTag" is being often used by devs.
